### PR TITLE
Add tests for account.get & account.profile.get when not signed in

### DIFF
--- a/tests/specs/get-profile.js
+++ b/tests/specs/get-profile.js
@@ -36,6 +36,14 @@ test('get profile details', function (t) {
   t.equal(profileInfo, state.session.account.profile, 'contains correct object')
 })
 
+test('get profile when user not logged in', function (t) {
+  t.plan(1)
+
+  var profileInfo = get({}, 'account.profile')
+
+  t.is(typeof profileInfo, 'undefined', 'returns undefined')
+})
+
 test('get profile fullName from string', function (t) {
   t.plan(2)
 

--- a/tests/specs/get-profile.js
+++ b/tests/specs/get-profile.js
@@ -36,7 +36,7 @@ test('get profile details', function (t) {
   t.equal(profileInfo, state.session.account.profile, 'contains correct object')
 })
 
-test('get profile when user not logged in', function (t) {
+test('get profile returns undefined when user not logged in', function (t) {
   t.plan(1)
 
   var profileInfo = get({}, 'account.profile')

--- a/tests/specs/get.js
+++ b/tests/specs/get.js
@@ -33,6 +33,14 @@ test('get account details', function (t) {
   t.equal(accountInfo, state.session.account, 'contains correct object')
 })
 
+test('get account when user not logged in', function (t) {
+  t.plan(1)
+
+  var accountInfo = get({}, 'account')
+
+  t.is(typeof accountInfo, 'undefined', 'returns undefined')
+})
+
 test('get account username from string', function (t) {
   t.plan(2)
 

--- a/tests/specs/get.js
+++ b/tests/specs/get.js
@@ -33,7 +33,7 @@ test('get account details', function (t) {
   t.equal(accountInfo, state.session.account, 'contains correct object')
 })
 
-test('get account when user not logged in', function (t) {
+test('get account returns undefined when user not logged in', function (t) {
   t.plan(1)
 
   var accountInfo = get({}, 'account')


### PR DESCRIPTION
Added tests for account.get & account.profile.get when not signed in,
passing in '{}' instead of state, tests return undefined correctly.
