### PR TITLE
Resolve account.signIn with session instead of account

### DIFF
--- a/lib/sign-in.js
+++ b/lib/sign-in.js
@@ -54,6 +54,6 @@ function signIn (state, options) {
       username: data.account.username
     })
 
-    return clone(state.session.account)
+    return clone(state.session)
   })
 }

--- a/tests/integration/events-test.js
+++ b/tests/integration/events-test.js
@@ -48,8 +48,8 @@ test('events', function (t) {
 
   .then(function (returnedObject) {
     var sessionData = store.getObject('_session')
-    t.is(returnedObject.username, options.username, 'returns correct username')
-    t.is(sessionData.account.username, returnedObject.username, 'stored correct username in session')
+    t.is(returnedObject.account.username, options.username, 'returns correct username')
+    t.is(sessionData.account.username, returnedObject.account.username, 'stored correct username in session')
     t.is(sessionData.id, signInResponse.data.id, 'stored correct session id')
 
     t.deepEqual(signInHandler.lastCall.arg, {

--- a/tests/unit/sign-in-test.js
+++ b/tests/unit/sign-in-test.js
@@ -36,7 +36,7 @@ test('signIn without username', function (t) {
 })
 
 test('successful account.signIn(options)', function (t) {
-  t.plan(5)
+  t.plan(6)
 
   var state = {
     url: 'http://example.com',
@@ -64,7 +64,7 @@ test('successful account.signIn(options)', function (t) {
     password: 'secret'
   })
 
-  .then(function (accountProperties) {
+  .then(function (sessionProperties) {
     t.deepEqual(signIn.internals.request.lastCall.arg, {
       method: 'PUT',
       url: 'http://example.com/session',
@@ -82,8 +82,9 @@ test('successful account.signIn(options)', function (t) {
       }
     })
 
-    t.equal(accountProperties.id, 'deserialise id', 'resolves with account.id')
-    t.equal(accountProperties.username, 'deserialise username', 'resolves with account.username')
+    t.assert(sessionProperties.account, 'resolves with account object')
+    t.equal(sessionProperties.account.id, 'deserialise id', 'resolves with account.id')
+    t.equal(sessionProperties.account.username, 'deserialise username', 'resolves with account.username')
 
     simple.restore()
   })


### PR DESCRIPTION
I think this takes care of #26. Look OK?

I had to fix the events test too, as it calls the signIn method and plays with the resolved value