### PR TITLE
Constructor for options.id

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,17 +52,65 @@ account.on('signout', redirectToHome)
 ### Constructor
 
 ```js
+new Account(options)
+```
+
+<table>
+  <thead>
+    <tr>
+      <th>Argument</th>
+      <th>Type</th>
+      <th>Description</th>
+      <th>Required</th>
+    </tr>
+  </thead>
+  <tr>
+    <th align="left"><code>options.url</code></th>
+    <td>String</td>
+    <td>Path or full URL to root location of the account JSON API</td>
+    <td>Yes</td>
+  </tr>
+  <tr>
+    <th align="left"><code>options.id</code></th>
+    <td>String</td>
+    <td>
+      The initial account id can be passed. Useful for apps that can be used
+      locally without an account.
+    </td>
+    <td>Defaults to random id</td>
+  </tr>
+  <tr>
+    <th align="left"><code>options.cacheKey</code></th>
+    <td>String</td>
+    <td>
+      Name of localStorage key where to persist the session state.
+    </td>
+    <td>Defaults to <code>\_session</code></td>
+  </tr>
+  <tr>
+    <th align="left"><code>options.validate</code></th>
+    <td>Function</td>
+    <td>
+      Optional function to validate account before sending
+      sign up / sign in / update requests
+    </td>
+    <td>No</td>
+  </tr>
+</table>
+
+Returns `account` API.
+
+Example
+
+```js
 new Account({
-  // required. Path or full URL to root location of the account JSON API
   url: '/api',
-  // name of localStorage key where to persist the session state.
-  // Defaults to "_session"
+  id: 'user123',
   cacheKey: 'myapp.session',
-  // function to validate account details
-  // defaults to return true
   validate: function (options) {
-    // "this" is the new Account
-    // "options" is an object with "username", "password", and "profile" properties
+    if (options.username.length < 3) {
+      throw new Error('Username must have at least 3 characters')
+    }
   }
 })
 ```
@@ -254,19 +302,16 @@ account.signIn(options)
   </tr>
 </table>
 
-Resolves with `sessionProperties`:
+Resolves with `accountProperties`:
 
 ```json
 {
-  "id": "session123",
-  "account": {
-    "id": "account123",
-    "username": "pat",
-    "createdAt": "2016-01-01T00:00.000Z",
-    "updatedAt": "2016-01-02T00:00.000Z",
-    "profile": {
-      "fullname": "Dr. Pat Hook"
-    }
+  "id": "account123",
+  "username": "pat",
+  "createdAt": "2016-01-01T00:00.000Z",
+  "updatedAt": "2016-01-02T00:00.000Z",
+  "profile": {
+    "fullname": "Dr. Pat Hook"
   }
 }
 ```
@@ -759,17 +804,33 @@ hoodie.off('connectionstatus:disconnected', showNotification)
 ### Events
 
 <table>
+  <thead>
+    <tr>
+      <th align="left">
+        Event
+      </th>
+      <th align="left">
+        Description
+      </th>
+      <th align="left">
+        Arguments
+      </th>
+    </tr>
+  </thead>
   <tr>
     <th align="left"><code>signup</code></th>
     <td>New user account created successfully</td>
+    <td><code>accountProperties</code> with <code>.session</code> property</td>
   </tr>
   <tr>
     <th align="left"><code>signin</code></th>
     <td>Successfully signed in to an account</td>
+    <td><code>accountProperties</code> with <code>.session</code> property</td>
   </tr>
   <tr>
     <th align="left"><code>signout</code></th>
     <td>Successfully signed out</td>
+    <td><code>accountProperties</code> with <code>.session</code> property</td>
   </tr>
   <tr>
     <th align="left"><code>passwordreset</code></th>
@@ -780,14 +841,14 @@ hoodie.off('connectionstatus:disconnected', showNotification)
     <td>
       Server responded with "unauthenticated" when checking session<br>
       🐕 <strong>TO BE DONE</strong> <a href="https://github.com/hoodiehq/hoodie-client-account/issues/35">#35</a>
-      </td>
+    </td>
   </tr>
   <tr>
     <th align="left"><code>reauthenticate</code></th>
     <td>
       Successfully signed in after "unauthenticated" state<br>
       🐕 <strong>TO BE DONE</strong> <a href="https://github.com/hoodiehq/hoodie-client-account/issues/35">#35</a>
-      </td>
+    </td>
   </tr>
 </table>
 

--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ function Account (options) {
     emitter: options.emitter || new EventEmitter(),
     session: getSession({cacheKey: cacheKey}),
     url: options.url,
+    id: options.id,
     validate: options.validate || function () {}
   }
 

--- a/lib/sign-in.js
+++ b/lib/sign-in.js
@@ -51,9 +51,12 @@ function signIn (state, options) {
 
     state.emitter.emit('signin', {
       id: data.account.id,
-      username: data.account.username
+      username: data.account.username,
+      session: {
+        id: data.id
+      }
     })
 
-    return clone(state.session)
+    return clone(data.account)
   })
 }

--- a/lib/sign-out.js
+++ b/lib/sign-out.js
@@ -25,12 +25,17 @@ function signOut (state) {
     internals.clearSession({
       cacheKey: state.cacheKey
     })
-    delete state.session
 
     state.emitter.emit('signout', {
       id: id,
-      username: username
+      username: username,
+      session: {
+        id: state.session.id
+      }
     })
+
+    delete state.session
+    delete state.id
 
     return clone(accountProperties)
   })

--- a/lib/sign-up.js
+++ b/lib/sign-up.js
@@ -25,7 +25,7 @@ function signUp (state, options) {
   return internals.request({
     url: state.url + '/session/account',
     method: 'PUT',
-    body: internals.serialise('account', options)
+    body: internals.serialise('account', options, options.id || state.id)
   })
 
   .then(function (response) {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "pretest:browser:local": "npm run -s build",
     "test:coverage": "istanbul cover tests",
     "test:coverage:upload": "istanbul-coveralls",
-    "test:node": "node tests"
+    "test:node": "node tests",
+    "test:watch": "gaze 'clear && tape tests | tap-min' index.js tests/**/*.js lib/**/*.js"
   },
   "repository": {
     "type": "git",
@@ -41,6 +42,7 @@
   "devDependencies": {
     "browserify": "^11.0.1",
     "doxx": "1.5.0",
+    "gaze-cli": "^0.2.0",
     "gh-pages-deploy": "^0.3.0",
     "istanbul": "^0.3.19",
     "istanbul-coveralls": "^1.0.3",
@@ -51,6 +53,7 @@
     "semantic-release": "^6.0.3",
     "simple-mock": "^0.5.0",
     "standard": "^5.2.2",
+    "tap-min": "^1.0.0",
     "tap-spec": "^4.1.0",
     "tape": "^4.2.0",
     "uglify-js": "^2.4.24"

--- a/tests/integration/events-test.js
+++ b/tests/integration/events-test.js
@@ -41,21 +41,22 @@ test('events', function (t) {
     t.deepEqual(signUpHandler.lastCall.arg, {
       id: 'abc4567',
       username: 'chicken@docs.com'
-    }, '"signup" event emitted with session object')
+    }, '"signup" event emitted with account object')
 
     return account.signIn(options)
   })
 
-  .then(function (returnedObject) {
+  .then(function (accountProperties) {
     var sessionData = store.getObject('_session')
-    t.is(returnedObject.account.username, options.username, 'returns correct username')
-    t.is(sessionData.account.username, returnedObject.account.username, 'stored correct username in session')
+    t.is(accountProperties.username, options.username, 'returns correct username')
+    t.is(sessionData.account.username, accountProperties.username, 'stored correct username in session')
     t.is(sessionData.id, signInResponse.data.id, 'stored correct session id')
 
     t.deepEqual(signInHandler.lastCall.arg, {
       id: 'abc4567',
-      username: 'chicken@docs.com'
-    }, '"signin" event emitted with session object')
+      username: 'chicken@docs.com',
+      session: { id: 'sessionid123' }
+    }, '"signin" event emitted with account object')
 
     return account.signOut()
   })
@@ -63,8 +64,9 @@ test('events', function (t) {
   .then(function () {
     t.deepEqual(signOutHandler.lastCall.arg, {
       id: 'abc4567',
-      username: 'chicken@docs.com'
-    }, '"signout" event emitted with session object')
+      username: 'chicken@docs.com',
+      session: { id: 'sessionid123' }
+    }, '"signout" event emitted with account object')
 
     t.is(signUpHandler.callCount, 1, '"signup" event emitted once')
     t.is(signInHandler.callCount, 1, '"signin" event emitted once')

--- a/tests/integration/sign-up-with-id.js
+++ b/tests/integration/sign-up-with-id.js
@@ -1,0 +1,51 @@
+var clone = require('lodash.clone')
+var nock = require('nock')
+var test = require('tape')
+
+var Account = require('../../index')
+
+var baseURL = 'http://localhost:3000'
+var signUpResponse = require('../fixtures/signup.json')
+var signInResponse = clone(require('../fixtures/signin.json'))
+signInResponse.data.relationships.account.data.id = 'newid123'
+signInResponse.included.id = 'newid123'
+
+var options = {
+  username: signUpResponse.data.attributes.username,
+  password: 'secret'
+}
+
+test('sign up with id', function (t) {
+  t.plan(2)
+
+  var account = new Account({
+    url: baseURL,
+    id: 'abc4567'
+  })
+
+  nock(baseURL)
+    .put('/session/account', function (body) {
+      t.is(body.data.id, 'abc4567', 'sends correct account id')
+      return true
+    })
+    .reply(201, signUpResponse)
+    .delete('/session')
+    .reply(204)
+    .put('/session/account', function (body) {
+      t.isNot(body.data.id, 'abc4567', 'sends new account id')
+      return true
+    })
+    .reply(201, signUpResponse)
+
+  account.signUp(options)
+
+  .then(function () {
+    return account.signOut()
+  })
+
+  .then(function () {
+    return account.signUp(options)
+  })
+
+  .catch(t.error)
+})

--- a/tests/unit/sign-in-test.js
+++ b/tests/unit/sign-in-test.js
@@ -64,7 +64,7 @@ test('successful account.signIn(options)', function (t) {
     password: 'secret'
   })
 
-  .then(function (sessionProperties) {
+  .then(function (accountProperties) {
     t.deepEqual(signIn.internals.request.lastCall.arg, {
       method: 'PUT',
       url: 'http://example.com/session',
@@ -82,9 +82,9 @@ test('successful account.signIn(options)', function (t) {
       }
     })
 
-    t.assert(sessionProperties.account, 'resolves with account object')
-    t.equal(sessionProperties.account.id, 'deserialise id', 'resolves with account.id')
-    t.equal(sessionProperties.account.username, 'deserialise username', 'resolves with account.username')
+    t.assert(accountProperties, 'resolves with account object')
+    t.equal(accountProperties.id, 'deserialise id', 'resolves with account.id')
+    t.equal(accountProperties.username, 'deserialise username', 'resolves with account.username')
 
     simple.restore()
   })

--- a/tests/unit/sign-up-test.js
+++ b/tests/unit/sign-up-test.js
@@ -60,14 +60,15 @@ test('signUp with username & password', function (t) {
     t.deepEqual(state.validate.lastCall.arg, {
       username: 'pat',
       password: 'secret'
-    })
+    }, 'passes username & password to validate')
     t.deepEqual(signUp.internals.serialise.lastCall.args, [
       'account',
       {
         username: 'pat',
         password: 'secret'
-      }
-    ])
+      },
+      undefined // state.id, from `new Account({id: ...})`
+    ], 'passes username & password to serialise')
     t.deepEqual(signUp.internals.request.lastCall.arg, {
       method: 'PUT',
       url: 'http://example.com/session/account',


### PR DESCRIPTION
Allow to initialise `account` API with an existing account.id. We need that
for `hoodie` as we allow users to create data before signing up for an account
and already store the `hoodie.id` with all data. Once the user signs up, the
created account needs to have the same id