### PR TITLE
signOut() resolves with account properties

### DIFF
--- a/lib/sign-out.js
+++ b/lib/sign-out.js
@@ -8,7 +8,7 @@ internals.clearSession = require('../utils/clear-session')
 internals.get = require('./get')
 
 function signOut (state) {
-  var accountProperties = internals.get(state, 'account')
+  var accountProperties = internals.get(state)
 
   return internals.request({
     method: 'DELETE',

--- a/test/integration/sign-in-test.js
+++ b/test/integration/sign-in-test.js
@@ -16,7 +16,7 @@ var options = {
 
 test('sign in', function (t) {
   store.clear()
-  t.plan(10)
+  t.plan(11)
 
   var account = new Account({
     url: baseURL,
@@ -59,8 +59,7 @@ test('sign in', function (t) {
   .then(function (signOutResult) {
     t.pass('signes out')
 
-    // https://github.com/hoodiehq/hoodie-client-account/issues/50
-    // t.is(signOutResult.username, 'chicken@docs.com')
+    t.is(signOutResult.username, 'chicken@docs.com')
 
     var storeAccount = store.getObject('account')
 


### PR DESCRIPTION
Closes #50 

Good starter issue, because I initially had a totally different solution which was way more complex, and after I dug into the internals (`get.js`) a bit I realised that the fix was to simply remove the `, 'account'`. :+1: 