### PR TITLE
WIP: #54 hoodie.account.fetch(), .update(), .profile.fetch() and .profile.update() should fail with UnauthenticatedError if session is invalid, but currently fails with "Not FoundError"

### DIFF
--- a/test/fixtures/get-session-404.json
+++ b/test/fixtures/get-session-404.json
@@ -1,0 +1,7 @@
+{
+    "errors": [{
+        "status": "404",
+        "title": "NotFoundError",
+        "detail": "Page Not Found"
+    }]
+}

--- a/test/integration/api-test.js
+++ b/test/integration/api-test.js
@@ -5,6 +5,7 @@ var test = require('tape')
 var Account = require('../../index')
 
 var sessionUnauthorizedResponse = require('../fixtures/put-session-401.json')
+var sessionNotFoundResponse = require('../fixtures/get-session-404.json')
 
 test('account.signIn() with invalid credentials', function (t) {
   t.plan(2)
@@ -28,5 +29,26 @@ test('account.signIn() with invalid credentials', function (t) {
   .catch(function (error) {
     t.is(error.name, 'UnauthorizedError', 'rejects with "UnauthorizedError" error')
     t.is(error.message, 'Invalid Credentials', 'rejects with correct message')
+  })
+})
+test('account.fetch() unauthenticated state', function (t) {
+  t.plan(2)
+
+  store.clear()
+  var account = new Account({
+    url: 'http://localhost:3000'
+  })
+
+  nock('http://localhost:3000')
+    .get('/session')
+    .reply(404, sessionNotFoundResponse)
+
+  account.fetch()
+
+  .then(t.fail.bind(t, 'must reject'))
+
+  .catch(function (error) {
+    t.is(error.name, 'UnauthenticatedError', 'rejects with "UnauthenticatedError" error')
+    t.is(error.message, 'Not signed in', 'rejects with correct message')
   })
 })

--- a/test/unit/fetch-test.js
+++ b/test/unit/fetch-test.js
@@ -38,3 +38,27 @@ test('fetch without state', function (t) {
     t.equal(error.name, 'UnauthenticatedError', 'rejects with UnauthenticatedError error')
   })
 })
+
+test('fetch with unauthenticated state', function (t) {
+  var error = new Error('NotFound')
+  error.name = 'NotFoundError'
+  error.status = 404
+  simple.mock(internals, 'fetchProperties').rejectWith(error)
+
+  t.plan(1)
+
+  fetch({
+    baseUrl: 'http://example.com',
+    account: {
+      session: {
+        id: 'abc4567'
+      }
+    }
+  }, 'path')
+
+  .then(t.fail.bind(t, 'Must reject'))
+  .catch(function (error) {
+    console.log(error)
+    t.equal(error.name, 'UnauthenticatedError', 'rejects with UnauthenticatedError error')
+  })
+})


### PR DESCRIPTION
closes #54