### PR TITLE
chore(gitignore): *~

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*~
 *.log
 .DS_Store
 coverage


### PR DESCRIPTION
adds a line for emacs backups to the `.gitignore`.

making this pr separate from any particular issue ensures that this minor irk w/ my development workflow can get sorted independently and out of order relative to more edits that _are_ related to open issues.